### PR TITLE
feat: add vercel analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kevin-wessa",
       "version": "0.2.0",
       "dependencies": {
+        "@vercel/analytics": "^1.2.2",
         "next": "^14.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -625,6 +626,26 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
+      "integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+      "dependencies": {
+        "server-only": "^0.0.1"
+      },
+      "peerDependencies": {
+        "next": ">= 13",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -4060,6 +4081,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "rm -rf .next/ && rm -rf node_modules/ && npm install"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.2.2",
     "next": "^14.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
### TL;DR

This PR introduces the `@vercel/analytics` dependency to the project.

### What changed?

The `@vercel/analytics` package was added both in `package.json` and `package-lock.json` files.

### How to test?

Check out to this branch and do `npm install` to ensure that the package is successfully installed.

### Why make this change?

This change is made to utilise Vercel's analytics package for comprehensive analytics and insights of the application.

---

